### PR TITLE
Systype proportional contribution

### DIFF
--- a/R_scripts/segregation.R
+++ b/R_scripts/segregation.R
@@ -15,7 +15,7 @@
 #     A list object is returned and contain the following elements - 
 #           S,    System segregation calcualted with W & B                 
 #           W,    Mean correlation between nodes within the same community     
-#           B,    Mean correlation obetween nodes from different community   
+#           B,    Mean correlation between nodes from different community   
 # #########################################################################
 #   Reference: Chan et al. (2014) PNAS E4997
 #   Micaela Chan, UTD

--- a/R_scripts/segregation_by_type_eqcon.R
+++ b/R_scripts/segregation_by_type_eqcon.R
@@ -1,17 +1,19 @@
-segregation_by_type <- function(M=NULL, Ci=NULL, C_Type=NULL, diagzero=TRUE, negzero=TRUE) {
+segregation_by_type_eqcont <- function(M=NULL, Ci=NULL, C_Type=NULL, diagzero=TRUE, negzero=TRUE) {
 # DESCRIPTION:
 #    Calculate versions of system segregation based on system-type (e.g., 
 #    average segregation of systems of a certain 'type' to systems of any
 #    type, from other systems of the same 'type,' and from systems of all
-#    other types; Chan et al. 2014). 
+#    other types). 
+#    ** In this version, the contribution of each 'system' is the same regardless of its size. 
+#    This is the version used in Chan et al. 2014 PNAS.
 #
 #  Inputs:   M,         Correlation matrix 
 #            Ci,        Community affiliation vector (e.g., system labels)
 #            C_Type,    Community type vector (e.g., sensory-motor, association). 
-#                       A node with type '0' is ignored when calcualting segregation between 
+#                       A node with type '0' is ignored when calculating segregation between 
 #					              other types of systems (B_other/seg_othertype)
-#            diagzero, 	Booleen for setting diagonal of input matrix to 0. Default=TRUE
-#            negzero,  	Booleen for setting negative edges of input matrix to 0. Default=TRUE
+#            diagzero, 	Boolean for setting diagonal of input matrix to 0. Default=TRUE
+#            negzero,  	Boolean for setting negative edges of input matrix to 0. Default=TRUE
 # 
 #  Outputs:  segresult  Dataframe with rows = systems, and columns as follow:  
 #            W_same,    Average of the mean correlation between nodes within the same

--- a/R_scripts/segregation_by_type_pcontr.R
+++ b/R_scripts/segregation_by_type_pcontr.R
@@ -1,0 +1,103 @@
+segregation_by_type_pcontr <- function(M=NULL, Ci=NULL, C_Type=NULL, diagzero=TRUE, negzero=TRUE) {
+# DESCRIPTION:
+#    Calculate versions of system segregation based on system-type (e.g., 
+#    average segregation of systems of a certain 'type' to systems of any
+#    type, from other systems of the same 'type,' and from systems of all
+#    other types. In this verison, the contribution of each 'system' is 
+#    proportional to its size. 
+#
+#  Inputs:   M,         Correlation matrix 
+#            Ci,        Community affiliation vector (e.g., system labels)
+#            C_Type,    Community type vector (e.g., sensory-motor, association). 
+#                       A node with type '0' is ignored when calcualting segregation between 
+#					              other types of systems (B_other/seg_othertype)
+#            diagzero, 	Booleen for setting diagonal of input matrix to 0. Default=TRUE
+#            negzero,  	Booleen for setting negative edges of input matrix to 0. Default=TRUE
+# 
+#  Outputs:  segresult  Dataframe with rows = systems, and columns as follow:  
+#            W_same,    Average of the mean correlation between nodes within the same
+#                       community of one system type
+#            B_all,     Average of edges between nodes from different communities
+#                       in all system types 
+#            B_same,    Average of edges between nodes from different communities
+#                       in the same system type
+#            B_other,   Average of edges between nodes from different communities
+#                    	  in the other system type
+#            seg_all,  	For each system-type, the average segregation from all
+#                   	  other communities that have an assigned system-type 
+#                       e.g., average segregation of association systems to
+#                       other association systems and sensory-motor system)
+#            seg_same,  For each system-type, the average segregation from
+#                   	  communities of the same type 
+#                       e.g., average association-to-association system segregation.
+#            seg_other, For each system-type, the average segregation from 
+#                   	  communities of all other types 
+#                       e.g., average association-to-sensory-motor system segregation.
+# ##########################################################################
+#   Reference: Chan et al. (2014) PNAS E4997
+#   2017-2018
+#   Micaela Chan, UTD
+#
+#   Modification History:
+#   Sep 2017: original (MYC)
+#   Oct 2018: Commented script (MYC)
+# #########################################################################
+
+  # warnings
+  if(!isSymmetric.matrix(M)) stop('Input matrix must be symmetric.')
+  if(dim(M)[1]!=length(Ci)) stop('Length of community vector does not match matrix dimension.')
+  if(dim(M)[1]!=length(C_Type)) stop('Length of community type vector does not match matrix dimension.')
+  
+  if(diagzero==TRUE){ # set diagonal to 0 if True
+    diag(M) <- 0
+  }
+  
+  if(negzero==TRUE){  # set negative to 0 if True
+    M[which(M<0)] <- 0
+  }
+  
+  UniqueType <- sort(unique(C_Type))
+  UniqueType <- UniqueType[which(UniqueType>0)] # 
+
+  segresult <- data.frame(W_same=matrix(NA,length(UniqueType)), # initializing final result data frame
+                          B_all=matrix(NA,length(UniqueType)),  
+                          B_same=matrix(NA,length(UniqueType)),
+                          B_other=matrix(NA,length(UniqueType)))
+  
+  for(i in 1:length(UniqueType)){ # Loop through system-type
+  
+    type_i <- which(C_Type==UniqueType[i])
+    Ci_specific <- unique(Ci[C_Type==UniqueType[i]])
+    
+    W_same <- vector(mode = "numeric")
+    B_all <- vector(mode = "numeric")
+    B_same <- vector(mode = "numeric")
+    B_other <- vector(mode = "numeric")
+    
+    # find index of communities not in current system-type (ignoring nodes not in either system types [i.e., '0']).
+    othertype_i <- which(C_Type!=UniqueType[i] & C_Type!=0) 
+    
+    for(j in 1:length(Ci_specific)){  # Loop through each community within current system-type
+        w.index <- as.vector(which(Ci==Ci_specific[j])) # find index of a single community within current system-type
+        b.index <- intersect(type_i, as.vector(which(Ci!=Ci_specific[j]))) # find index of other communities within current system-type
+		
+        w.mat <- M[w.index, w.index]
+        
+        W_same <- append(W_same, w.mat[upper.tri(M[w.index, w.index],diag=FALSE)]) # extract within-community edges
+        B_all <- append (B_all, M[w.index, c(b.index, othertype_i)])     # extract between-comm edges with any other communities (same or diff type)
+        B_same <- append(B_same, M[w.index, b.index])                    # extract between-comm edges with same-type of communities 		
+        B_other <- append(B_other, M[w.index, othertype_i])              # extract between-comm edges with other-type(s) of communities        
+    }
+    segresult[i,] <- c(mean(W_same, na.rm=T), mean(B_all,na.rm=T), mean(B_same,na.rm=T), mean(B_other,na.rm=T))
+    
+    # segresult[i,] <- colMeans(Ci_result, na.rm=TRUE)
+  }
+  
+  # Calculating segregation (all, same-type, other-type)
+  segresult$seg_all <- (segresult$W_same-segresult$B_all)/segresult$W_same
+  segresult$seg_same <- (segresult$W_same-segresult$B_same)/segresult$W_same
+  segresult$seg_other <- (segresult$W_same-segresult$B_other)/segresult$W_same
+  
+  row.names(segresult) <- UniqueType
+  return(segresult)
+}

--- a/R_scripts/segregation_by_type_prcont.R
+++ b/R_scripts/segregation_by_type_prcont.R
@@ -1,4 +1,4 @@
-segregation_by_type_pcontr <- function(M=NULL, Ci=NULL, C_Type=NULL, diagzero=TRUE, negzero=TRUE) {
+segregation_by_type_prcont <- function(M=NULL, Ci=NULL, C_Type=NULL, diagzero=TRUE, negzero=TRUE) {
 # DESCRIPTION:
 #    Calculate versions of system segregation based on system-type (e.g., 
 #    average segregation of systems of a certain 'type' to systems of any

--- a/R_scripts/segregation_by_type_prcont.R
+++ b/R_scripts/segregation_by_type_prcont.R
@@ -3,16 +3,16 @@ segregation_by_type_prcont <- function(M=NULL, Ci=NULL, C_Type=NULL, diagzero=TR
 #    Calculate versions of system segregation based on system-type (e.g., 
 #    average segregation of systems of a certain 'type' to systems of any
 #    type, from other systems of the same 'type,' and from systems of all
-#    other types. In this verison, the contribution of each 'system' is 
+#    other types. In this venison, the contribution of each 'system' is 
 #    proportional to its size. 
 #
 #  Inputs:   M,         Correlation matrix 
 #            Ci,        Community affiliation vector (e.g., system labels)
 #            C_Type,    Community type vector (e.g., sensory-motor, association). 
-#                       A node with type '0' is ignored when calcualting segregation between 
+#                       A node with type '0' is ignored when calculating segregation between 
 #					              other types of systems (B_other/seg_othertype)
-#            diagzero, 	Booleen for setting diagonal of input matrix to 0. Default=TRUE
-#            negzero,  	Booleen for setting negative edges of input matrix to 0. Default=TRUE
+#            diagzero, 	Boolean for setting diagonal of input matrix to 0. Default=TRUE
+#            negzero,  	Boolean for setting negative edges of input matrix to 0. Default=TRUE
 # 
 #  Outputs:  segresult  Dataframe with rows = systems, and columns as follow:  
 #            W_same,    Average of the mean correlation between nodes within the same
@@ -34,11 +34,11 @@ segregation_by_type_prcont <- function(M=NULL, Ci=NULL, C_Type=NULL, diagzero=TR
 #                   	  communities of all other types 
 #                       e.g., average association-to-sensory-motor system segregation.
 # ##########################################################################
-#   Reference: Chan et al. (2014) PNAS E4997
-#   2017-2018
+#   Reference: Chan et al. (2014) PNAS E4997; Chan et al. (submitted; 2021)
 #   Micaela Chan, UTD
 #
 #   Modification History:
+#   May 2021: Modified calculation from 2014 version system-type segregation
 #   Sep 2017: original (MYC)
 #   Oct 2018: Commented script (MYC)
 # #########################################################################

--- a/test/test_segtype_proc.R
+++ b/test/test_segtype_proc.R
@@ -1,0 +1,42 @@
+df$seg_asso_proc[1]
+df$seg_sensory_proc[1]
+
+sense_i <- which(label$Chan_system_type_label[i_349]==1)
+asso_i <- which(label$Chan_system_type_label[i_349]==2)
+
+p349 <- label$Power_label[i_349]
+
+submat <- cube349[,,1]
+submat_noneg <- submat
+submat_noneg[submat < 0 ] <- 0
+
+w.mat <- submat_noneg[sense_i, sense_i]
+mean_sense <- mean(w.mat[upper.tri(submat_noneg[sense_i, sense_i],diag=FALSE)])
+
+
+# manually calculate sensory-motor within, between-same, between-other
+mean(c(submat_noneg[p349==4, p349==4][upper.tri(submat_noneg[p349==4, p349==4],diag=FALSE)],
+        submat_noneg[p349==5, p349==5][upper.tri(submat_noneg[p349==5, p349==5],diag=FALSE)],
+        submat_noneg[p349==16, p349==16][upper.tri(submat_noneg[p349==16, p349==16],diag=FALSE)],
+        submat_noneg[p349==24, p349==24][upper.tri(submat_noneg[p349==24, p349==24],diag=FALSE)]))
+
+mean(c(submat_noneg[p349==4, is.element(p349, c(5,16,24))],
+       submat_noneg[p349==5, is.element(p349, c(4,16,24))],
+       submat_noneg[p349==16,is.element(p349, c(5,4,24))],
+       submat_noneg[p349==24,is.element(p349, c(5,16,4))]))
+
+mean(c(submat_noneg[p349==4, is.element(p349, c(3,6,7,14,15,20))],
+       submat_noneg[p349==5, is.element(p349, c(3,6,7,14,15,20))],
+       submat_noneg[p349==16,is.element(p349, c(3,6,7,14,15,20))],
+       submat_noneg[p349==24,is.element(p349, c(3,6,7,14,15,20))]))
+
+
+w.mat <- submat_noneg[asso_i, asso_i]
+mean_asso <- mean(w.mat[upper.tri(submat_noneg[asso_i, asso_i],diag=FALSE)])
+
+
+segtype_proc <- segregation_by_type_pcontr(M = submat, Ci = label$Power_label[i_349], 
+                                           C_Type = label$Chan_system_type_label[i_349], diagzero = T, negzero = T)
+
+
+segtype_proc$W_same


### PR DESCRIPTION
`segregation_by_type_pcontr.R` is an updated way of calculating system-type segregation that allows functional systems with different sizes to contribute proportional to their sizes to the system-type system segregation.

* within- and between- system connectivity is **not averaged per-system** (like in `segregation_by_type_eqcont.R`) 

`segregation_by_type_eqcont.R` is how system-type segregation was originally calculated in Chan et al. 2014. 
* within- and between-system connectivity is **first averaged for each system** before being averaged together to calculate system-type within/between connectivity. 

